### PR TITLE
Small fixes

### DIFF
--- a/src/app/docs/[[...mdxPath]]/page.tsx
+++ b/src/app/docs/[[...mdxPath]]/page.tsx
@@ -6,6 +6,7 @@ export const generateStaticParams = generateStaticParamsFor("mdxPath");
 export async function generateMetadata(props: any) {
   const params = await props.params;
   const { metadata } = await importPage(params.mdxPath);
+  metadata.title = `${metadata?.title} - Reagraph`;
 
   return metadata;
 }

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -44,7 +44,14 @@ const navbar = (
  */
 const RootLayout: FC<PropsWithChildren> = async ({ children }) => (
   <html lang='en' dir='ltr' suppressHydrationWarning className='h-full'>
-    <Head />
+    <Head>
+      <link rel='preconnect' href='https://fonts.googleapis.com' />
+      <link rel='preconnect' href='https://fonts.gstatic.com' />
+      <link
+        href='https://fonts.googleapis.com/css2?family=Inter:ital,opsz,wght@0,14..32,100..900;1,14..32,100..900&family=Lexend:wght@100..900&display=swap'
+        rel='stylesheet'
+      />
+    </Head>
     <body className='flex flex-col bg-gradient-to-b from-[#11111F] from-50% via-[#11111F] to-[#121212] antialiased overflow-x-hidden text-white'>
       <Layout
         navbar={navbar}

--- a/src/components/blocks/footer.tsx
+++ b/src/components/blocks/footer.tsx
@@ -9,7 +9,7 @@ import { ResponsiveContainer } from '../responsive-container';
 
 export const Footer: FC = () => {
   return (
-    <div className='w-full justify-center items-center'>
+    <div className='w-full justify-center items-center font-inter'>
       <ResponsiveContainer className='flex items-center justify-between gap-4'>
         <Image
           src={'/assets/logo-full.png'}

--- a/src/components/blocks/header.tsx
+++ b/src/components/blocks/header.tsx
@@ -41,7 +41,7 @@ export const Header = () => {
           <Stack className='gap-8'>
             {NAV_LINKS.map((link) => (
               <NextLink
-                className='px-4 hover:text-primary transition-colors duration-200 ease-in-out'
+                className='px-4 text-base text-text-secondary hover:text-text-primary font-semibold transition-colors duration-200 ease-in-out'
                 href={link.href}
                 target={link.target}
                 key={link.label}

--- a/src/content/getting-started/Installing.mdx
+++ b/src/content/getting-started/Installing.mdx
@@ -1,11 +1,14 @@
+import { Steps } from 'nextra/components'
+
 # Getting Started
 
 ## Installing
 
 You can install reagraph with [NPM](https://www.npmjs.com/package/reagraph) or Yarn.
 
-- NPM: `npm install reagraph --save`
-- YARN: `yarn add reagraph`
+```sh copy npm2yarn
+npm install reagraph --save
+```
 
 ## Compatibility
 
@@ -14,13 +17,26 @@ reagraph is compatible with React v16+ and works with ReactDOM. React Native is 
 ## Developing
 
 If you want to run the project locally, its really easy!
-
 The project uses Storybook for its demos and development
 environment. To run it locally:
 
-- Clone repo
-- `npm i`
-- `npm start`
+
+<Steps>
+### Clone repo
+```sh
+git clone git@github.com:reaviz/reagraph.git
+```
+
+### Install dependencies
+```sh copy npm2yarn
+npm i
+```
+
+### Start the development server
+```sh copy npm2yarn
+npm run start
+```
+</Steps>
 
 Once started the browser will open to the storybook url.
 From here you can tweak the charts and see them build


### PR DESCRIPTION
- Align font in header and footer with other docs sites
- Add Reagraph suffix to the docs pages title
- use `sh copy npm2yarn` in docs

![Screenshot 2025-07-08 at 16 09 26](https://github.com/user-attachments/assets/f1d30f8e-0eb3-405d-a75a-755c3cb1f5e3)

