### PR TITLE
Migrate deployment from Netlify to Cloudflare Pages

### DIFF
--- a/instrumentation-client.ts
+++ b/instrumentation-client.ts
@@ -1,9 +1,8 @@
 import posthog from "posthog-js";
 
 posthog.init('phc_AtQPBMWBjgLhPQcqTeRTTNvntWbFezkEqZ28u2mqLRM', {
-  api_host: "/ingest",
+  api_host: "https://us.i.posthog.com",
   ui_host: "https://us.posthog.com",
   defaults: '2025-05-24',
-  capture_exceptions: true, // This enables capturing exceptions using Error Tracking, set to false if you don't want this
-  // debug: process.env.NODE_ENV === "development",
+  capture_exceptions: true,
 });

--- a/next.config.ts
+++ b/next.config.ts
@@ -10,27 +10,10 @@ const withNextra = nextra({
 
 const nextConfig: NextConfig = withNextra({
   reactStrictMode: true,
-
-  // Rewrites required for PostHog ingestion endpoints
-  async rewrites() {
-    return [
-      {
-        source: '/ingest/static/:path*',
-        destination: 'https://us-assets.i.posthog.com/static/:path*',
-      },
-      {
-        source: '/ingest/:path*',
-        destination: 'https://us.i.posthog.com/:path*',
-      },
-      {
-        source: '/ingest/decide',
-        destination: 'https://us.i.posthog.com/decide',
-      },
-    ];
+  output: 'export',
+  images: {
+    unoptimized: true,
   },
-
-  // This is required to support PostHog trailing slash API requests
-  skipTrailingSlashRedirect: true,
 
   webpack(config) {
     // Grab the existing rule that handles SVG imports

--- a/package.json
+++ b/package.json
@@ -6,12 +6,11 @@
   "scripts": {
     "dev": "next dev",
     "build": "next build",
-    "build:cloudflare": "npx @cloudflare/next-on-pages",
     "start": "next start",
     "postinstall": "cp node_modules/reagraph/dist/docs/docgen.json src/data/reagraph-docgen.json",
-    "postbuild": "pagefind --site .next/server/app --output-path public/_pagefind",
+    "postbuild": "pagefind --site out --output-path out/_pagefind",
     "lint": "next lint",
-    "preview": "npx wrangler pages dev .vercel/output/static"
+    "preview": "npx wrangler pages dev out"
   },
   "browser": {
     "fs": false,

--- a/src/app/docs/[[...mdxPath]]/page.tsx
+++ b/src/app/docs/[[...mdxPath]]/page.tsx
@@ -1,7 +1,7 @@
-import { importPage } from "nextra/pages";
+import { importPage, generateStaticParamsFor } from "nextra/pages";
 import { useMDXComponents } from "@/mdx-components";
 
-export const runtime = 'edge';
+export const generateStaticParams = generateStaticParamsFor("mdxPath");
 
 export async function generateMetadata(props: any) {
   const params = await props.params;

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -1,10 +1,6 @@
 name = "reagraph-website"
 compatibility_date = "2024-09-23"
-compatibility_flags = ["nodejs_compat"]
 
-[vars]
-NODE_ENV = "production"
-
-# Pages-specific configuration
-pages_build_output_dir = ".vercel/output/static"
+# Pages-specific configuration - point to static export output
+pages_build_output_dir = "out"
 


### PR DESCRIPTION
- Configure Next.js for static export with `output: 'export'`
- Add generateStaticParams for Nextra docs pages
- Update PostHog to use direct API endpoint instead of rewrites
- Simplify wrangler.toml for static site deployment
- Update build scripts to output to `out` directory